### PR TITLE
Post-build command for paths that contain spaces

### DIFF
--- a/DwarfCorp/DwarfCorpContent/credits.json
+++ b/DwarfCorp/DwarfCorpContent/credits.json
@@ -76,8 +76,15 @@
     "RandomFlash": false,
     "Divider": false
   },
-  {
+{
     "Name": "Jason Berg",
+    "Role": "Programming Contractor",
+    "Color": [ 255, 255, 255, 255 ],
+    "RandomFlash": false,
+    "Divider": false
+},
+  {
+    "Name": "Christian Cajas",
     "Role": "Programming Contractor",
     "Color": [255, 255, 255, 255],
     "RandomFlash": false,

--- a/DwarfCorp/DwarfCorpXNA/DwarfCorpXNA.csproj
+++ b/DwarfCorp/DwarfCorpXNA/DwarfCorpXNA.csproj
@@ -699,7 +699,7 @@
     <PreBuildEvent>(if exist "$(TargetDir)*old.pdb" del "$(TargetDir)*old.pdb") &amp; (if exist "$(TargetDir)*.pdb" ren "$(TargetDir)*.pdb" *.old.pdb)</PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>MKDIR $(SolutionDir)DwarfCorpFNA\bin\$(ConfigurationName)\Content  &amp; XCOPY $(ProjectDir)$(OutDir)Content $(SolutionDir)DwarfCorpFNA\bin\$(ConfigurationName)\Content /Y /E</PostBuildEvent>
+    <PostBuildEvent>MKDIR "$(SolutionDir)DwarfCorpFNA\bin\$(ConfigurationName)\Content" &amp; XCOPY "$(ProjectDir)$(OutDir)Content" "$(SolutionDir)DwarfCorpFNA\bin\$(ConfigurationName)\Content" /Y /E</PostBuildEvent>
   </PropertyGroup>
   <!--
       To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
First PR from my branch. Build commands for the XNA project are fixed when it throws errors if the file paths contain spaces. Also added name to credits.json.