### PR TITLE
Optimized WorldManager.EnumerateIntersectionObjects

### DIFF
--- a/DwarfCorp/DwarfCorpXNA/Tools/Datastructures/OctTree.cs
+++ b/DwarfCorp/DwarfCorpXNA/Tools/Datastructures/OctTree.cs
@@ -43,7 +43,7 @@ namespace DwarfCorp
         {
             return Bounds.Contains(Box);
         }
-
+        
         private void Subdivide()
         {
             //lock (Lock) //All calls are from inside already locked functions.
@@ -122,7 +122,7 @@ namespace DwarfCorp
                 }
             }
         }
-
+        
         public void EnumerateItems(HashSet<Body> Into)
         {
             lock (this)
@@ -245,7 +245,7 @@ namespace DwarfCorp
                     case ContainmentType.Contains:
                         if (Children == null)
                             for (var i = 0; i < Items.Count; ++i)
-                                Into.Add(Items[i].Body);
+                                    Into.Add(Items[i].Body);
                         else
                             for (var i = 0; i < 8; ++i)
                                 Children[i].EnumerateItems(Into);

--- a/DwarfCorp/DwarfCorpXNA/World/WorldManager-OctTree.cs
+++ b/DwarfCorp/DwarfCorpXNA/World/WorldManager-OctTree.cs
@@ -31,6 +31,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Newtonsoft.Json;
@@ -51,11 +52,14 @@ namespace DwarfCorp
             return hash;
         }
 
-        public IEnumerable<Body> EnumerateIntersectingObjects(BoundingFrustum Frustum)
+        public IEnumerable<Body> EnumerateIntersectingObjects(BoundingFrustum Frustum, Func<Body, bool> Filter = null)
         {
             PerformanceMonitor.PushFrame("CollisionManager.EnumerateFrustum");
             var hash = new HashSet<Body>();
-            OctTree.EnumerateItems(Frustum, hash);
+            if (Filter == null)
+                OctTree.EnumerateItems(Frustum, hash);
+            else
+                OctTree.EnumerateItems(Frustum, hash, Filter);
             PerformanceMonitor.PopFrame();
             return hash;
         }

--- a/DwarfCorp/DwarfCorpXNA/World/WorldManager.cs
+++ b/DwarfCorp/DwarfCorpXNA/World/WorldManager.cs
@@ -849,8 +849,8 @@ namespace DwarfCorp
                 return;
 
             var frustum = Camera.GetDrawFrustum();
-            var renderables = EnumerateIntersectingObjects(frustum)
-                .Where(r => r.IsVisible && !ChunkManager.IsAboveCullPlane(r.GetBoundingBox()));
+            var renderables = EnumerateIntersectingObjects(frustum,
+                r => r.IsVisible && !ChunkManager.IsAboveCullPlane(r.GetBoundingBox()));
 
             // Controls the sky fog
             float x = (1.0f - Sky.TimeOfDay);


### PR DESCRIPTION
According to the Visual Studio profiler (on release mode), the game was
spending about 26% of execution time in
Microsoft.XMA.Framework.BoundingBox.Intersect(BoundingFrustum) playing a
small map with about 5 dwarves and quite a bit of wildlife.

This method is only used by the renderer to enumerate visible bodies in a
recursive frustum-AABB intersection test.
Besides the method itself which uses a seemingly unbounded loop, there
might be some calling overhead due to the method lying in a external assembly.

I replaced it with a more optimized version called OctTreeNode.FastIntersects
and added a version of OctTreeNode.EnumerateItems with a Filter parameter
to more aggressively cull bodies.
This reduces the time spent by EnumerateIntersectionObjects to 8%,
and seems to improve the FPS and reduce jitter.

As described in http://old.cescg.org/CESCG-2002/DSykoraJJelinek/
there is room for further improvement, such as using plane masking
(where if we know that an octree lies one side of a plane, then all
its children also lie that side of the plane so we don't need to test again),
or some sort of frame-to-frame coherency where the results of the last
frame are used to speed up the body culling of the current frame.