### PR TITLE
Fix cooking

### DIFF
--- a/DwarfCorp/DwarfCorpXNA/Scripting/TaskManagement/Tasks/CraftResourceTask.cs
+++ b/DwarfCorp/DwarfCorpXNA/Scripting/TaskManagement/Tasks/CraftResourceTask.cs
@@ -144,6 +144,9 @@ namespace DwarfCorp
             if (!agent.Stats.IsTaskAllowed(Category))
                 return Feasibility.Infeasible;
 
+            if (agent.AI.Status.IsAsleep)
+                return Feasibility.Infeasible;
+
             return HasResources(agent) && HasLocation(agent) ? Feasibility.Feasible : Feasibility.Infeasible;
         }
 

--- a/DwarfCorp/DwarfCorpXNA/Scripting/TaskManagement/Tasks/CraftResourceTask.cs
+++ b/DwarfCorp/DwarfCorpXNA/Scripting/TaskManagement/Tasks/CraftResourceTask.cs
@@ -67,7 +67,7 @@ namespace DwarfCorp
                 Valid = true,
                 SelectedResources = SelectedResources
             };
-            Name = String.Format("Craft order {0}", TaskID);
+            Name = String.Format("Craft order {0}: {1} {2}s", TaskID, NumRepeats, selectedResource);
             Priority = PriorityType.Low;
 
             if (ResourceLibrary.GetResourceByName(Item.ItemType.ResourceCreated).Tags.Contains(Resource.ResourceTags.Edible))


### PR DESCRIPTION
This patchset includes the following fixes mostly for cooking in CraftResourceTask:

-    Use TaskCategory.Cook not TaskCategory.Craft for cooking
-    Consider agent.AI.Status.IsAsleep for feasibility checking, like CraftItemTask does (not sure if needed, if not you may want to remove that from all task implementations)
-    Add number of items and item type to the task name, so we know which task is crafting what

All of these are completely untested since I lack a VS dev environment; should be easy enough to fix in case I messed up.