### PR TITLE
Fix build with Mono 5.14.0

### DIFF
--- a/DwarfCorp/DwarfCorpXNA/Scripting/Adventure/Adventure.cs
+++ b/DwarfCorp/DwarfCorpXNA/Scripting/Adventure/Adventure.cs
@@ -527,7 +527,7 @@ namespace DwarfCorp.Scripting.Adventure
                 else
                 {
                     stolenGoods.Add(new ResourceAmount(Datastructures.SelectRandom(destGoods).ResourceType, MathFunctions.RandInt(1, 5)));
-                    stolenMoney += (decimal)MathFunctions.RandInt(1, 100);
+                    stolenMoney += (DwarfBux)(decimal)MathFunctions.RandInt(1, 100);
                 }
             }
 
@@ -630,7 +630,7 @@ namespace DwarfCorp.Scripting.Adventure
                 return;
             }
 
-            decimal tradeValue = (Resources.Sum(r => GetValue(ResourceLibrary.GetResourceByName(r.ResourceType), des) * r.NumResources) + Money) * charisma;
+            decimal tradeValue = (Resources.Sum(r => GetValue(ResourceLibrary.GetResourceByName(r.ResourceType), des) * r.NumResources) + (decimal)Money) * (decimal)charisma;
 
             if (MathFunctions.Rand(0, 500) < (float)tradeValue)
             {

--- a/DwarfCorp/DwarfCorpXNA/Scripting/Factions/Faction.cs
+++ b/DwarfCorp/DwarfCorpXNA/Scripting/Factions/Faction.cs
@@ -919,7 +919,7 @@ namespace DwarfCorp
                     return remainingSpace > 0;
                 });
                 // Generate a number of coin piles.
-                for (DwarfBux total = 0m; total < amountRemaining; total += 1024m)
+                for (DwarfBux total = 0m; total < amountRemaining; total += (DwarfBux)1024m)
                 {
                     Zone randomZone = Datastructures.SelectRandom(RoomBuilder.DesignatedRooms);
                     Vector3 point = MathFunctions.RandVector3Box(randomZone.GetBoundingBox()) +

--- a/DwarfCorp/DwarfCorpXNA/Scripting/Gambling.cs
+++ b/DwarfCorp/DwarfCorpXNA/Scripting/Gambling.cs
@@ -296,8 +296,8 @@ namespace DwarfCorp.Scripting
                 var money = participant.Status.Money;
 
                 var bet = (decimal)(int)(MathFunctions.Rand(0.1f, 0.25f) * money);
-                Pot += bet;
-                participant.Status.Money -= bet;
+                Pot += (DwarfBux)bet;
+                participant.Status.Money -= (DwarfBux)bet;
 
                 IndicatorManager.DrawIndicator((-(DwarfBux)bet).ToString(),
                     participant.AI.Position + Microsoft.Xna.Framework.Vector3.Up , 4.0f, 

--- a/DwarfCorp/DwarfCorpXNA/Scripting/LeafActs/StashMoneyAct.cs
+++ b/DwarfCorp/DwarfCorpXNA/Scripting/LeafActs/StashMoneyAct.cs
@@ -97,7 +97,7 @@ namespace DwarfCorp
                 yield break;
             }
             Timer waitTimer = new Timer(1.0f, true);
-            var moneyRemoved = Math.Min(Money, Zone.Money);
+            DwarfBux moneyRemoved = Math.Min(Money, Zone.Money);
             bool removed = Zone.RemoveMoney(Agent.Position, moneyRemoved);
 
             if(!removed)


### PR DESCRIPTION
Fix a number of ambiguous invocations of overloaded operators to unbreak the build using latest Mono Stable on macOS instead of cross-compiling from Visual Studio on Windows.